### PR TITLE
Added a RemovedContractFix

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ For an install guide see here: [https://github.com/janxious/ModTek/wiki/The-Drop
 - RemovedFlashpointFix
    - This fix removes invalid flashpoints allowing saves to load if a user created flashpoint was removed from the mods in use.
 - DisableSimAnimations
-   - Make all simgame room transitions instant. 
+   - Make all simgame room transitions instant.
+- RemovedContractsFix
+   - This fix removes invalid contracts allowing saves to load if a user created contract was removed from the mods in use.
 
 # Experimental patches
 - MDDB_TagsetQueryInChunks

--- a/source/BattletechPerformanceFix.csproj
+++ b/source/BattletechPerformanceFix.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -117,6 +117,7 @@
     <Compile Include="PatchMechLabLimitItems.cs" />
     <Compile Include="EnableLoggingDuringLoads.cs" />
     <Compile Include="RemovedFlashpointFix.cs" />
+    <Compile Include="RemovedContractsFix.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\mod.json" />

--- a/source/Main.cs
+++ b/source/Main.cs
@@ -95,6 +95,7 @@ namespace BattletechPerformanceFix
                     { typeof(DisableDeployAudio), false },
                     { typeof(RemovedFlashpointFix), true },
                     { typeof(DisableSimAnimations), false },
+                    { typeof(RemovedContractsFix), true },
                 };
                                
                 Dictionary<Type, bool> want = allFeatures.ToDictionary(f => f.Key, f => settings.features.TryGetValue(f.Key.Name, out var userBool) ? userBool : f.Value);

--- a/source/RemovedContractsFix.cs
+++ b/source/RemovedContractsFix.cs
@@ -1,0 +1,22 @@
+﻿using System.Collections.Generic;
+using BattleTech;
+using BattleTech.Save;
+using BattleTech.Framework;
+using HBS.Data;
+
+namespace BattletechPerformanceFix
+{
+    class RemovedContractsFix : Feature
+    {
+        public void Activate()
+        {
+            "Rehydrate".Pre<SimGameState>();
+        }
+
+        static void Rehydrate_Pre(SimGameState __instance, GameInstanceSave gameInstanceSave)
+        {
+            IDataItemStore<string, ContractOverride> contractOverrides = __instance.DataManager.ContractOverrides;
+            gameInstanceSave.SimGameSave.ContractBits.RemoveAll(item => !contractOverrides.Exists(item.conName));
+        }
+    }
+}


### PR DESCRIPTION
PFix didn't load a save when a contract in the save was loaded but that original mod no longer was running. This allows the save to load.