### PR TITLE
Navigation map difficulty filter lag fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -267,3 +267,4 @@ __pycache__/
 
 libs/
 libs.fixed/
+*/*.swp

--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@
    - Make all simgame room transitions instant.
 - RemovedContractsFix
    - This fix removes invalid contracts allowing saves to load if a user created contract was removed from the mods in use.
+- NavigationMapFilterLagFix
+   - This fix removes some unnecessary code in the navigation map's difficulty filter selection.
+   - The performance gain is negligible in vanilla, but in modpacks using the entire IS map such as RT or BTA, this saves a few seconds.
 
 # Experimental patches
 - MDDB_TagsetQueryInChunks

--- a/source/BattletechPerformanceFix.csproj
+++ b/source/BattletechPerformanceFix.csproj
@@ -53,6 +53,7 @@
     <Compile Include="LocalizationPatches.cs" />
     <Compile Include="HarmonyPatches.cs" />
     <Compile Include="ContractLagFix.cs" />
+    <Compile Include="NavigationMapFilterLagFix.cs" />
     <Compile Include="DisableSensitiveDataLogDump.cs" />
     <Compile Include="DisableDeployAudio.cs" />
     <Compile Include="DisableSimAnimations.cs" />

--- a/source/BattletechPerformanceFix.csproj
+++ b/source/BattletechPerformanceFix.csproj
@@ -67,7 +67,7 @@
     <Compile Include="LoadFixes.cs" />
     <Compile Include="ShaderDependencyOverride.cs" />
     <Compile Include="ShopTabLagFix.cs" />
-    <Compile Include="PatchMechLabLimitItems.cs" />
+    <Compile Include="PatchMechlabLimitItems.cs" />
     <Compile Include="EnableLoggingDuringLoads.cs" />
     <Compile Include="RemovedFlashpointFix.cs" />
     <Compile Include="RemovedContractsFix.cs" />

--- a/source/Main.cs
+++ b/source/Main.cs
@@ -91,6 +91,7 @@ namespace BattletechPerformanceFix
                     { typeof(DataLoaderGetEntryCheck), true },
                     { typeof(ShopTabLagFix), true },
                     { typeof(ContractLagFix), true },
+                    { typeof(NavigationMapFilterLagFix), true },
                     { typeof(EnableLoggingDuringLoads), true },
                     { typeof(ExtraLogging), true },
                     { typeof(ShaderDependencyOverride), true },

--- a/source/NavigationMapFilterLagFix.cs
+++ b/source/NavigationMapFilterLagFix.cs
@@ -1,0 +1,63 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using BattleTech.UI;
+using Harmony;
+using System.Reflection.Emit;
+using HBS;
+using static BattletechPerformanceFix.Extensions;
+
+namespace BattletechPerformanceFix
+{
+    /* Removes a redundant call for creating difficulty callouts, saves a few seconds per filter selection */
+    class NavigationMapFilterLagFix : Feature
+    {
+        public void Activate()
+        {
+            var method = AccessTools.Method(typeof(SGNavigationScreen), "OnDifficultySelectionChanged");
+            var transpiler = new HarmonyMethod(typeof(NavigationMapFilterLagFix), nameof(Transpiler));
+            Main.harmony.Patch(method, null, null, transpiler);
+
+            var cdc = nameof(SGNavigationScreen.CreateDifficultyCallouts);
+            cdc.Pre<SGNavigationScreen>();
+            cdc.Post<SGNavigationScreen>();
+            var rsi = nameof(SGNavigationScreen.RefreshSystemIndicators);
+            rsi.Pre<SGNavigationScreen>();
+            rsi.Post<SGNavigationScreen>();
+        }
+        
+        // FIXME remove
+        // TODO write a wrapper to make these quickly & easily
+        public static void CreateDifficultyCallouts_Pre(ref Stopwatch __state)
+        { __state = new Stopwatch(); __state.Start(); }
+        public static void CreateDifficultyCallouts_Post(ref Stopwatch __state)
+        { __state.Stop(); LogDebug("[PROFILE] " + __state.Elapsed + " CreateDifficultyCallouts"); }
+        public static void RefreshSystemIndicators_Pre(ref Stopwatch __state)
+        { __state = new Stopwatch(); __state.Start(); }
+        public static void RefreshSystemIndicators_Post(ref Stopwatch __state)
+        { __state.Stop(); LogDebug("[PROFILE] " + __state.Elapsed + " RefreshSystemIndicators"); }
+
+        static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
+        {
+            // cuts out the if/else block in CreateDifficultyCallouts() because CreateDifficultyCallouts()
+            // is called later by RefreshSystemIndicators() anyways just after the block
+            // FIXME? this technique is v fragile but we don't expect:
+            //        - other mods modifying this chunk of IL
+            //        - updates to the game (1.9.1 is supposedly the final release)
+            // but this is mostly just for test purposes anyway so YOLO
+            // FIXME? maybe faster to leave instructions in enumerable form &
+            //        not convert it to a list & back
+            int startIndex = 7;
+            int endIndex = 15;
+
+            LogInfo("Overwriting instructions in SGNavigationScreen.OnDifficultySelectionChanged()" +
+                    " at indices " + startIndex + " through " + endIndex + " with nops");
+            var codes = new List<CodeInstruction>(instructions);
+            for(int i = startIndex; i <= endIndex; i++) {
+                LogSpam("overwriting index " + i + " value " + codes[i].opcode + " with nop");
+                codes[i].opcode = OpCodes.Nop;
+            }
+
+            return codes.AsEnumerable();
+        }
+    }
+}


### PR DESCRIPTION
Removes some unnecessary logic from the navigation map's difficulty selection filter.

In BT modpacks that use the full IS map, the difficulty selection filter lags quite a bit, much more so than vanilla. This PR patches the difficulty selector to remove unnecessary calls to the function that creates the difficulty callouts on the navigation map. It still lags quite a bit, but this change is an improvement.